### PR TITLE
Clean BUILD_DIR instead of removing it

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,8 +28,8 @@ APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 (
     mv "${BUILD_DIR}/${COPY_DIR}" "${BUILD_DIR}/${APP_BASE}" &&
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    rm -rf "${BUILD_DIR}" &&
-    mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
+    rm -rf "${BUILD_DIR}/{*,.*}" &&
+    mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}/"
 )
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Why: Heroku CI does not like the folder being removed `rm: cannot remove '/app': Read-only file system`