### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 Imagine you have a single code base, which has a few different applications within it... or at least the ability to run a few different applications. Or, maybe you're Google with your mono repo?
 
-In any case, how do you manage this on Heroku? You don't. Heroku applications assume one repo to one application. 
+In any case, how do you manage this on Heroku? You don't. Heroku applications assume one repo to one application.
 
-Enter the Multi Procfile buildpack, where every app gets a Procfile!
+Enter the Monorepo buildpack, which is a copy of [heroku-buildpack-multi-procfile](https://github.com/heroku/heroku-buildpack-multi-procfile) except it moves the target path in to the root, rather than just the Procfile. This helps for ruby apps etc.
 
 # Usage
 
-1. Write a bunch of Procfiles and scatter them through out your code base.
+1. Write a bunch of ~~Procfiles~~ apps and scatter them through out your code base.
 2. Create a bunch of Heroku apps.
-3. For each app, set `PROCFILE=relative/path/to/Procfile/in/your/codebase`, and of course:
-   `heroku buildpacks:add -a <app> https://github.com/heroku/heroku-buildpack-multi-procfile`
+3. For each app, set `APP_BASE=relative/path/to/app/root`, and of course:
+   `heroku buildpacks:add -a <app> https://github.com/lstoll/heroku-buildpack-monorepo`
 4. For each app, `git push git@heroku.com:<app> master`
 
 # Authors
 
-Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com>
+Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com> and now Lincoln Stoll <lstoll@heroku.com>

--- a/bin/compile
+++ b/bin/compile
@@ -8,12 +8,10 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-APP_BAE=$(cat ${APP_BASE}/PROCFILE)
-
-if [[ -z "${APP_BASE}" ]]; then
+if [ ! -f ${ENV_DIR}/APP_BASE ]; then
     echo "APP_BASE was not set. Aborting" | indent
-    exit 1
 fi
+APP_BASE=$(cat ${ENV_DIR}/APP_BASE)
 
 (
     stage=`mktemp -d` &&

--- a/bin/compile
+++ b/bin/compile
@@ -8,18 +8,25 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-PROCFILE=$(cat ${ENV_DIR}/PROCFILE)
+APP_BAE=$(cat ${APP_BASE}/PROCFILE)
 
-if [[ -z "${PROCFILE}" ]]; then
-    echo "PROCFILE was not set. Aborting" | indent
+if [[ -z "${APP_BASE}" ]]; then
+    echo "APP_BASE was not set. Aborting" | indent
     exit 1
 fi
 
-cp ${BUILD_DIR}/${PROCFILE} ${BUILD_DIR}/Procfile
+(
+    stage=`mktemp -d` &&
+    mv ${BUILD_DIR}/${APP_BASE} ${stage} &&
+    shopt -s dotglob nullglob &&
+    rm -rf ${BUILD_DIR}/* &&
+    mv ${stage}/${APP_BASE}/* ${BUILD_DIR}
+)
 
 if ! [ $? ]; then
     echo "FAILED to copy a Procfile" | indent
     exit 1
 fi
 
-echo "Copied ${PROCFILE} as Procfile successfully" | indent
+echo "Copied ${APP_BASE} to root of app successfully" | indent
+

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-echo "Multi-procfile"
+echo "Monorepo"
 exit 0


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack fail with errors like:

```
remote: -----> Monorepo app detected
remote: rm: cannot remove '/app': Read-only file system
remote:       FAILED to copy directory into place
remote:  !     Push rejected, failed to compile Monorepo app.
```

A fix for this compatibility issue has been merged into the upstream repository from which this one is forked:
lstoll/heroku-buildpack-monorepo/pull/13

This PR merges the changes from the upstream repository (which include that fix) back to this fork, so as to avoid any disruption to your builds in the future.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
lstoll/heroku-buildpack-monorepo/issues/12

I'm also happy to answer any questions you may have via discussion on this PR :-)